### PR TITLE
feat: tuto validator

### DIFF
--- a/app/database/dao/text_entry.py
+++ b/app/database/dao/text_entry.py
@@ -2,7 +2,7 @@ import hashlib
 import logging
 from tqdm import tqdm
 
-from app.parser.tools.info_text import normalize_info_text
+from app.parser.tools.info_text import normalize_info_text, normalize_tuto_text
 
 from ..db import get_db
 from ..entity.text_entry import TextEntry
@@ -133,9 +133,17 @@ class TextEntryDao:
                 # FIXME: 这里最好统一
                 translated_content = trans_content.replace("\\n", "\n") if trans_content else db_entry.original
 
-                if trans_content and filename.lower() == "f2info.bin":
+                normalizer = None
+                if trans_content:
+                    lower_filename = filename.lower()
+                    if lower_filename == "f2info.bin":
+                        normalizer = normalize_info_text
+                    elif lower_filename == "f2tuto.bin":
+                        normalizer = normalize_tuto_text
+
+                if normalizer:
                     try:
-                        translated_content, _ = normalize_info_text(
+                        translated_content, _ = normalizer(
                             translated_content,
                             entry_label=f"{filename} entry {db_entry.entry_index}",
                         )

--- a/app/parser/tools/info_text.py
+++ b/app/parser/tools/info_text.py
@@ -4,8 +4,12 @@ from app.parser.tools import common
 INFO_TITLE_MAX_BYTES = 34
 INFO_LINE_MAX_BYTES = 54
 INFO_BODY_LINES_PER_PAGE = 5
+TUTO_TITLE_MAX_BYTES = INFO_TITLE_MAX_BYTES
+TUTO_LINE_MAX_BYTES = INFO_LINE_MAX_BYTES
+TUTO_BODY_LINES_PER_PAGE = 6
 
 _FULLWIDTH_PAGE_DIGITS = "１２３４５６７８９"
+_ASCII_PAGE_DIGITS = "123456789"
 
 
 def _encoded_length(text: str) -> int:
@@ -17,14 +21,51 @@ def _fail(entry_label: str, message: str) -> None:
     raise ValueError(prefix + message)
 
 
-def _wrap_encoded_line(text: str) -> list[str]:
+class _DetailTextLayout:
+    def __init__(
+        self,
+        title_max_bytes: int,
+        line_max_bytes: int,
+        body_lines_per_page: int,
+        first_page_prefix: str,
+        next_page_prefix: str,
+        page_separator: str,
+    ):
+        self.title_max_bytes = title_max_bytes
+        self.line_max_bytes = line_max_bytes
+        self.body_lines_per_page = body_lines_per_page
+        self.first_page_prefix = first_page_prefix
+        self.next_page_prefix = next_page_prefix
+        self.page_separator = page_separator
+
+
+_INFO_LAYOUT = _DetailTextLayout(
+    title_max_bytes=INFO_TITLE_MAX_BYTES,
+    line_max_bytes=INFO_LINE_MAX_BYTES,
+    body_lines_per_page=INFO_BODY_LINES_PER_PAGE,
+    first_page_prefix="\n",
+    next_page_prefix="\n\n",
+    page_separator="$n\n\n",
+)
+
+_TUTO_LAYOUT = _DetailTextLayout(
+    title_max_bytes=TUTO_TITLE_MAX_BYTES,
+    line_max_bytes=TUTO_LINE_MAX_BYTES,
+    body_lines_per_page=TUTO_BODY_LINES_PER_PAGE,
+    first_page_prefix="",
+    next_page_prefix="\n",
+    page_separator="$n\n",
+)
+
+
+def _wrap_encoded_line(text: str, max_bytes: int) -> list[str]:
     lines = []
     current = ""
     current_bytes = 0
 
     for char in text:
         char_bytes = _encoded_length(char)
-        if current and current_bytes + char_bytes > INFO_LINE_MAX_BYTES:
+        if current and current_bytes + char_bytes > max_bytes:
             lines.append(current.rstrip())
             current = ""
             current_bytes = 0
@@ -56,20 +97,24 @@ def _extract_paragraphs(body: str) -> list[str]:
     return paragraphs
 
 
-def _paginate_paragraphs(paragraphs: list[str]) -> list[list[str]]:
+def _paginate_paragraphs(
+    paragraphs: list[str],
+    line_max_bytes: int,
+    lines_per_page: int,
+) -> list[list[str]]:
     pages = [[]]
 
     for paragraph in paragraphs:
-        wrapped_lines = _wrap_encoded_line(paragraph)
+        wrapped_lines = _wrap_encoded_line(paragraph, line_max_bytes)
         if pages[-1]:
-            remaining_lines = INFO_BODY_LINES_PER_PAGE - len(pages[-1])
+            remaining_lines = lines_per_page - len(pages[-1])
             if remaining_lines <= 1:
                 pages.append([])
             else:
                 pages[-1].append("")
 
         for line in wrapped_lines:
-            if len(pages[-1]) >= INFO_BODY_LINES_PER_PAGE:
+            if len(pages[-1]) >= lines_per_page:
                 pages.append([])
             pages[-1].append(line)
 
@@ -77,8 +122,11 @@ def _paginate_paragraphs(paragraphs: list[str]) -> list[list[str]]:
     return pages or [[""]]
 
 
-def validate_info_text(text: str, entry_label: str = "") -> None:
-    """Validate f2info text without changing translator-controlled layout."""
+def _validate_detail_text(
+    text: str,
+    layout: _DetailTextLayout,
+    entry_label: str,
+) -> None:
     if "\0" in text:
         _fail(entry_label, "contains an embedded NUL byte")
     if "\r" in text:
@@ -100,10 +148,10 @@ def validate_info_text(text: str, entry_label: str = "") -> None:
     title_bytes = _encoded_length(title)
     if not title:
         _fail(entry_label, "title must not be empty")
-    if title_bytes > INFO_TITLE_MAX_BYTES:
+    if title_bytes > layout.title_max_bytes:
         _fail(
             entry_label,
-            f"title is {title_bytes} encoded bytes; maximum is {INFO_TITLE_MAX_BYTES}",
+            f"title is {title_bytes} encoded bytes; maximum is {layout.title_max_bytes}",
         )
 
     pages = body.split("$n")
@@ -115,7 +163,9 @@ def validate_info_text(text: str, entry_label: str = "") -> None:
         )
 
     for page_index, raw_page in enumerate(pages):
-        expected_prefix = "\n" if page_index == 0 else "\n\n"
+        expected_prefix = (
+            layout.first_page_prefix if page_index == 0 else layout.next_page_prefix
+        )
         if not raw_page.startswith(expected_prefix):
             _fail(
                 entry_label,
@@ -136,25 +186,28 @@ def validate_info_text(text: str, entry_label: str = "") -> None:
             content = raw_page[len(expected_prefix) :]
 
         lines = content.split("\n") if content else []
-        if len(lines) > INFO_BODY_LINES_PER_PAGE:
+        if len(lines) > layout.body_lines_per_page:
             _fail(
                 entry_label,
                 f"page {page_index + 1} has {len(lines)} body lines; "
-                f"maximum is {INFO_BODY_LINES_PER_PAGE}",
+                f"maximum is {layout.body_lines_per_page}",
             )
 
         for line_index, line in enumerate(lines, start=1):
             line_bytes = _encoded_length(line)
-            if line_bytes > INFO_LINE_MAX_BYTES:
+            if line_bytes > layout.line_max_bytes:
                 _fail(
                     entry_label,
                     f"page {page_index + 1}, line {line_index} is "
-                    f"{line_bytes} encoded bytes; maximum is {INFO_LINE_MAX_BYTES}",
+                    f"{line_bytes} encoded bytes; maximum is {layout.line_max_bytes}",
                 )
 
 
-def repair_info_text(text: str, entry_label: str = "") -> str:
-    """Rebuild f2info body layout while preserving title and body wording."""
+def _repair_detail_text(
+    text: str,
+    layout: _DetailTextLayout,
+    entry_label: str,
+) -> str:
     if "\0" in text:
         _fail(entry_label, "contains an embedded NUL byte")
     if "\r" in text:
@@ -167,7 +220,10 @@ def repair_info_text(text: str, entry_label: str = "") -> str:
         _fail(entry_label, "must contain a page-count line and a title line")
 
     page_count_text, title, body = parts
-    if len(page_count_text) != 1 or page_count_text not in _FULLWIDTH_PAGE_DIGITS:
+    if (
+        len(page_count_text) != 1
+        or page_count_text not in _FULLWIDTH_PAGE_DIGITS + _ASCII_PAGE_DIGITS
+    ):
         _fail(
             entry_label,
             "page count must be one full-width digit from １ to ９",
@@ -176,13 +232,17 @@ def repair_info_text(text: str, entry_label: str = "") -> str:
         _fail(entry_label, "title must not be empty")
 
     title_bytes = _encoded_length(title)
-    if title_bytes > INFO_TITLE_MAX_BYTES:
+    if title_bytes > layout.title_max_bytes:
         _fail(
             entry_label,
-            f"title is {title_bytes} encoded bytes; maximum is {INFO_TITLE_MAX_BYTES}",
+            f"title is {title_bytes} encoded bytes; maximum is {layout.title_max_bytes}",
         )
 
-    pages = _paginate_paragraphs(_extract_paragraphs(body))
+    pages = _paginate_paragraphs(
+        _extract_paragraphs(body),
+        line_max_bytes=layout.line_max_bytes,
+        lines_per_page=layout.body_lines_per_page,
+    )
     if len(pages) > len(_FULLWIDTH_PAGE_DIGITS):
         _fail(
             entry_label,
@@ -192,19 +252,53 @@ def repair_info_text(text: str, entry_label: str = "") -> str:
     rendered_pages = ["\n".join(page) for page in pages]
     repaired = (
         f"{_FULLWIDTH_PAGE_DIGITS[len(pages) - 1]}\n"
-        f"{title}\n\n"
-        + "$n\n\n".join(rendered_pages)
+        f"{title}\n"
+        + layout.first_page_prefix
+        + layout.page_separator.join(rendered_pages)
         + "\n"
     )
-    validate_info_text(repaired, entry_label=entry_label)
+    _validate_detail_text(repaired, layout=layout, entry_label=entry_label)
     return repaired
 
 
-def normalize_info_text(text: str, entry_label: str = "") -> tuple[str, bool]:
-    """Return valid text unchanged, otherwise return a safely reformatted body."""
+def _normalize_detail_text(
+    text: str,
+    layout: _DetailTextLayout,
+    entry_label: str,
+) -> tuple[str, bool]:
     try:
-        validate_info_text(text, entry_label=entry_label)
+        _validate_detail_text(text, layout=layout, entry_label=entry_label)
         return text, False
     except ValueError:
-        repaired = repair_info_text(text, entry_label=entry_label)
+        repaired = _repair_detail_text(text, layout=layout, entry_label=entry_label)
         return repaired, repaired != text
+
+
+def validate_info_text(text: str, entry_label: str = "") -> None:
+    """Validate f2info text without changing translator-controlled layout."""
+    _validate_detail_text(text, layout=_INFO_LAYOUT, entry_label=entry_label)
+
+
+def repair_info_text(text: str, entry_label: str = "") -> str:
+    """Rebuild f2info body layout while preserving title and body wording."""
+    return _repair_detail_text(text, layout=_INFO_LAYOUT, entry_label=entry_label)
+
+
+def normalize_info_text(text: str, entry_label: str = "") -> tuple[str, bool]:
+    """Return valid f2info text unchanged, otherwise safely reformat it."""
+    return _normalize_detail_text(text, layout=_INFO_LAYOUT, entry_label=entry_label)
+
+
+def validate_tuto_text(text: str, entry_label: str = "") -> None:
+    """Validate f2tuto detail text without changing translator-controlled layout."""
+    _validate_detail_text(text, layout=_TUTO_LAYOUT, entry_label=entry_label)
+
+
+def repair_tuto_text(text: str, entry_label: str = "") -> str:
+    """Rebuild f2tuto body layout while preserving title and body wording."""
+    return _repair_detail_text(text, layout=_TUTO_LAYOUT, entry_label=entry_label)
+
+
+def normalize_tuto_text(text: str, entry_label: str = "") -> tuple[str, bool]:
+    """Return valid f2tuto text unchanged, otherwise safely reformat it."""
+    return _normalize_detail_text(text, layout=_TUTO_LAYOUT, entry_label=entry_label)


### PR DESCRIPTION
差异是 tuto 原始格式标题后没有空行，分页是 $n\n，因此每页可用 6 行正文；info 因标题后空行占一个槽，是 5 行正文。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added validation, repair, and normalization support for tutorial text.
  * Tutorial text is now automatically formatted with the correct page structure, line limits, and encoding constraints.
  * Improved handling of page-count digits during text repair.

* **Bug Fixes**
  * Translation archive rebuilding now applies the appropriate normalization rules to both information and tutorial text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->