### PR TITLE
fix: Adjust impulse stat calculation in character status read function

### DIFF
--- a/plugin/src/runtime/character_status_overlay_core.c
+++ b/plugin/src/runtime/character_status_overlay_core.c
@@ -88,7 +88,7 @@ uint32_t Eva2CharacterStatus_Read(
     case EVA2_CHARACTER_STAT_AT:
         return character->at;
     case EVA2_CHARACTER_STAT_IMPULSE:
-        return character->impulse;
+        return character->impulse / 10u;
     case EVA2_CHARACTER_STAT_TRANSACTION:
         return character->transaction;
     case EVA2_CHARACTER_STAT_INTELLIGENCE:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the displayed impulse stat by applying the appropriate value scaling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->